### PR TITLE
chore: remove ruff from dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,5 +55,5 @@ This will look for tests in the `tests` directory and execute them.
 The project uses `ruff` for linting and formatting code. You can manually run the linter to check and fix code quality issues by executing:
 
 ```bash
-ruff check --fix .
+uvx ruff check --fix .
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,6 @@ test = [
     "pytest>=8.3.3",
 ]
 dev = [
-    "ruff>=0.6.7",
     "pytest>=8.3.3",
     "pre-commit>=3.8.0",
 ]


### PR DESCRIPTION
Per lecture, use uvx for tools, also already a pre-commit hook.