### PR TITLE
feat: global statistics

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,6 @@ uv run src/hifz -h
 Here are some examples one can run the dummy data:
 ```bash
 uv pip install -e .[gui]
-uv run src/hifz cli data/arabic_letters.json random
-uv run src/hifz gui data/fruits.csv mastery
+uv run src/hifz cli RandomStrategy --file-path data/arabic_letters.json
+uv run src/hifz gui MasterStrategy --file-path data/fruits.csv
 ```

--- a/src/hifz/card_engine.py
+++ b/src/hifz/card_engine.py
@@ -1,6 +1,7 @@
 """The card engine maintains the logic associated with user interaction and content production."""
 
 from pathlib import Path
+from typing import Any
 
 from hifz.dataserver import DataServer
 from hifz.learning_strategies import CardStrategy
@@ -50,6 +51,18 @@ class CardEngine:
         """Loads a session from saved progress."""
         self.session = CardSession.load_progress(file_path)
         self.strategy = self.session.strategy  # TODO: bad hack.
+
+    def aggregate_statistics(self) -> dict[str, Any]:
+        """Gets global statistics from the CardSession."""
+        return self.session.aggregate_statistics()
+
+    def render_statistics(self) -> str:
+        """Creates a string representation of a global statistics dictionary."""
+        statistics = self.aggregate_statistics()
+        return (
+            f"Correct: {statistics.get('total_correct', 0)}, "
+            + f"Incorrect: {statistics.get('total_incorrect', 0)}."
+        )
 
     def __str__(self) -> str:
         """Human-readable representation of the CardEngine."""

--- a/src/hifz/card_engine.py
+++ b/src/hifz/card_engine.py
@@ -56,14 +56,6 @@ class CardEngine:
         """Gets global statistics from the CardSession."""
         return self.session.aggregate_statistics()
 
-    def render_statistics(self) -> str:
-        """Creates a string representation of a global statistics dictionary."""
-        statistics = self.aggregate_statistics()
-        return (
-            f"Correct: {statistics.get('total_correct', 0)}, "
-            + f"Incorrect: {statistics.get('total_incorrect', 0)}."
-        )
-
     def __str__(self) -> str:
         """Human-readable representation of the CardEngine."""
         return (

--- a/src/hifz/learning_strategies.py
+++ b/src/hifz/learning_strategies.py
@@ -127,7 +127,7 @@ class RandomStrategy(CardStrategy):
         for card in cards:
             total_correct += card.statistics.get(key="correct", default=0)
             total_incorrect += card.statistics.get(key="incorrect", default=0)
-        return {"total_correct": total_correct, "total_incorrect": total_incorrect}
+        return {"Correct": total_correct, "Incorrect": total_incorrect}
 
 
 @register_strategy("SequentialStrategy")

--- a/src/hifz/learning_strategies.py
+++ b/src/hifz/learning_strategies.py
@@ -40,6 +40,10 @@ class CardStrategy(ABC):
     def create_feedback(self) -> Feedback:
         """Defines the type of feedback the strategy uses."""
 
+    @abstractmethod
+    def aggregate_statistics(self, cards: list[Card]) -> dict[str, Any]:
+        """Computes global statistics."""
+
     def to_dict(self) -> dict[str, Any]:
         """Serializes the strategy state."""
         strategy_name = STRATEGY_CLASS_TO_NAME.get(type(self))
@@ -116,6 +120,15 @@ class RandomStrategy(CardStrategy):
         """Gets the type of Feedback this strategy uses."""
         return BinaryFeedback("correct")
 
+    def aggregate_statistics(self, cards: list[Card]) -> dict[str, Any]:
+        """Computes total number of correct and incorrect."""
+        total_correct = 0
+        total_incorrect = 0
+        for card in cards:
+            total_correct += card.statistics.get(key="correct", default=0)
+            total_incorrect += card.statistics.get(key="incorrect", default=0)
+        return {"total_correct": total_correct, "total_incorrect": total_incorrect}
+
 
 @register_strategy("SequentialStrategy")
 class SequentialStrategy(CardStrategy):
@@ -148,6 +161,13 @@ class SequentialStrategy(CardStrategy):
     def create_feedback(self) -> Feedback:
         """Gets the type of Feedback this strategy uses."""
         return BinaryFeedback("correct")
+
+    def aggregate_statistics(self, cards: list[Card]) -> dict[str, Any]:
+        """Placeholder."""
+        global_statistics = {}
+        for card in cards:
+            global_statistics[card.front] = card.statistics
+        return global_statistics
 
 
 @register_strategy("MasteryStrategy")
@@ -201,6 +221,13 @@ class MasteryStrategy(CardStrategy):
     def create_feedback(self) -> Feedback:
         """Gets the type of Feedback this strategy uses."""
         return BinaryFeedback("correct")
+
+    def aggregate_statistics(self, cards: list[Card]) -> dict[str, Any]:
+        """Placeholder."""
+        global_statistics = {}
+        for card in cards:
+            global_statistics[card.front] = card.statistics
+        return global_statistics
 
     def _serialize_state(self) -> dict[str, Any]:
         """Serializes the strategy state."""
@@ -290,3 +317,10 @@ class SimpleSpacedRepetitionStrategy(CardStrategy):
     def create_feedback(self) -> Feedback:
         """Defines the type of feedback this strategy uses."""
         return BinaryFeedback("correct")
+
+    def aggregate_statistics(self, cards: list[Card]) -> dict[str, Any]:
+        """Placeholder."""
+        global_statistics = {}
+        for card in cards:
+            global_statistics[card.front] = card.statistics
+        return global_statistics

--- a/src/hifz/utils.py
+++ b/src/hifz/utils.py
@@ -3,6 +3,7 @@
 import json
 from datetime import datetime
 from pathlib import Path
+from typing import Any
 
 from hifz.learning_strategies import (
     STRATEGY_NAME_TO_CLASS,
@@ -62,6 +63,10 @@ class CardSession:
 
         cards = [Card.from_dict(card_data) for card_data in session_data["cards"]]
         return cls(cards=cards, strategy=strategy)
+
+    def aggregate_statistics(self) -> dict[str, Any]:
+        """Gets global statistics from the Strategy."""
+        return self.strategy.aggregate_statistics(self.cards)
 
     def __repr__(self) -> str:
         """Machine-readable representation of the CardSession."""

--- a/src/hifz/visualizers/__init__.py
+++ b/src/hifz/visualizers/__init__.py
@@ -24,3 +24,7 @@ class CardInterface(ABC):
     @abstractmethod
     def run_session(self, engine: CardEngine) -> None:
         """Runs the session."""
+
+    @abstractmethod
+    def display_statistics(self, engine: CardEngine) -> None:
+        """Computes the global statistics and displays a representation to be displayed to the user."""

--- a/src/hifz/visualizers/cli.py
+++ b/src/hifz/visualizers/cli.py
@@ -20,6 +20,11 @@ class CLICardInterface(CardInterface):
         """Notifies with message."""
         print(message)  # noqa: T201
 
+    def display_statistics(self, engine: CardEngine) -> None:
+        """Notifies the user of the global statistics."""
+        statistics = engine.session.aggregate_statistics()
+        self.notify("\n".join(f"{key}: {val}" for key, val in statistics.items()))
+
     def get_user_feedback(self, feedback: Feedback) -> Feedback:
         """Dynamically prompts for feedback based on Feedback structure."""
         match feedback:
@@ -94,4 +99,4 @@ class CLICardInterface(CardInterface):
 
         # Add a line to separate the summary statistics.
         self.notify("-" * 69)
-        self.notify(engine.render_statistics())
+        self.display_statistics(engine)

--- a/src/hifz/visualizers/cli.py
+++ b/src/hifz/visualizers/cli.py
@@ -22,7 +22,7 @@ class CLICardInterface(CardInterface):
 
     def display_statistics(self, engine: CardEngine) -> None:
         """Notifies the user of the global statistics."""
-        statistics = engine.session.aggregate_statistics()
+        statistics = engine.aggregate_statistics()
         self.notify("\n".join(f"{key}: {val}" for key, val in statistics.items()))
 
     def get_user_feedback(self, feedback: Feedback) -> Feedback:

--- a/src/hifz/visualizers/cli.py
+++ b/src/hifz/visualizers/cli.py
@@ -91,3 +91,7 @@ class CLICardInterface(CardInterface):
             feedback = engine.get_feedback()
             user_feedback = self.get_user_feedback(feedback)
             engine.process_feedback(card, user_feedback)
+
+        # Add a line to separate the summary statistics.
+        self.notify("-" * 69)
+        self.notify(engine.render_statistics())

--- a/src/hifz/visualizers/gui.py
+++ b/src/hifz/visualizers/gui.py
@@ -147,12 +147,18 @@ class GUICardInterface(CardInterface):
         """Notifies the user with a message."""
         QMessageBox.information(self.window, "Notification", message)
 
+    def display_statistics(self, engine: CardEngine) -> None:
+        """Notifies the user of the global statistics."""
+        statistics = engine.session.aggregate_statistics()
+        self.notify("\n".join(f"{key}: {val}" for key, val in statistics.items()))
+
     def run_session(self, engine: CardEngine) -> None:
         """Launches the session."""
         self.engine = engine
         self.show_next_card()
         self.window.show()
         self.app.exec()
+        self.display_statistics(engine)
 
     def show_next_card(self) -> None:
         """Displays the next card."""

--- a/src/hifz/visualizers/gui.py
+++ b/src/hifz/visualizers/gui.py
@@ -149,7 +149,7 @@ class GUICardInterface(CardInterface):
 
     def display_statistics(self, engine: CardEngine) -> None:
         """Notifies the user of the global statistics."""
-        statistics = engine.session.aggregate_statistics()
+        statistics = engine.aggregate_statistics()
         self.notify("\n".join(f"{key}: {val}" for key, val in statistics.items()))
 
     def run_session(self, engine: CardEngine) -> None:

--- a/tests/test_card_engine.py
+++ b/tests/test_card_engine.py
@@ -185,3 +185,20 @@ def test_engine_load_with_invalid_strategy(tmp_path_factory, utf8_test_file):
         ValueError, match="Unsupported strategy type: NonExistentStrategy"
     ):
         new_engine.load_progress(save_file)
+
+
+def test_summary(utf8_test_file):
+    """Test global session statistics."""
+    engine = CardEngine(RandomStrategy())
+    engine.load_cards(str(utf8_test_file))
+    for _ in range(5):
+        card = engine.get_next_card()
+        feedback = engine.get_feedback()
+        feedback.data["correct"] = True
+        engine.process_feedback(card, feedback)
+    for _ in range(3):
+        card = engine.get_next_card()
+        feedback = engine.get_feedback()
+        feedback.data["correct"] = False
+        engine.process_feedback(card, feedback)
+    assert engine.render_statistics() == "Correct: 5, Incorrect: 3."

--- a/tests/test_card_engine.py
+++ b/tests/test_card_engine.py
@@ -187,7 +187,7 @@ def test_engine_load_with_invalid_strategy(tmp_path_factory, utf8_test_file):
         new_engine.load_progress(save_file)
 
 
-def test_summary(utf8_test_file):
+def test_global_statistics(utf8_test_file):
     """Test global session statistics."""
     engine = CardEngine(RandomStrategy())
     engine.load_cards(str(utf8_test_file))
@@ -201,4 +201,4 @@ def test_summary(utf8_test_file):
         feedback = engine.get_feedback()
         feedback.data["correct"] = False
         engine.process_feedback(card, feedback)
-    assert engine.render_statistics() == "Correct: 5, Incorrect: 3."
+    assert engine.session.aggregate_statistics() == {"Correct": 5, "Incorrect": 3}


### PR DESCRIPTION
Adds `aggregate_statistics` method to each strategy to provide a way to compute global statistics. The current implementation for the `RandomStrategy` is to add up the total correct and incorrect answers across all cards answered. The total is displayed to the user upon ending the session. This is currently only implemented for cli and `RandomStrategy`. This can be extended to many different kinds of global statistics in the future. The implementations for the other strategies are currently placeholders to be updated in the future.

Also updates the README to show updated example usage.