### PR TITLE
refactor: rename visualizers to visualizers

### DIFF
--- a/src/hifz/__main__.py
+++ b/src/hifz/__main__.py
@@ -8,8 +8,8 @@ from hifz.learning_strategies import (
     STRATEGY_NAME_TO_CLASS,
     CardStrategy,
 )
-from hifz.visualizers import CardInterface
-from hifz.visualizers.cli import CLICardInterface
+from hifz.visualizers import Visualizer
+from hifz.visualizers.cli import CLIVisualizer
 
 
 def get_args() -> argparse.Namespace:
@@ -54,17 +54,17 @@ def get_strategy(strategy_name: str) -> CardStrategy:
     return strategy_cls()
 
 
-def get_visualizer(visualizer: str) -> CardInterface:
+def get_visualizer(visualizer: str) -> Visualizer:
     """Returns the desired visualizer."""
     match visualizer:
         case "cli":
-            return CLICardInterface()
+            return CLIVisualizer()
         case "gui":
             try:
-                from hifz.visualizers.gui import GUICardInterface
+                from hifz.visualizers.gui import GUIVisualizer
             except ImportError as e:
                 raise e
-            return GUICardInterface()
+            return GUIVisualizer()
         case _:
             error_message = f"{visualizer} is not a valid visualizer"
             raise ValueError(error_message)
@@ -75,7 +75,7 @@ def main() -> None:
     args = get_args()
 
     strategy = get_strategy(args.strategy)
-    interface = get_visualizer(args.visualizer)
+    visualizer = get_visualizer(args.visualizer)
 
     engine = CardEngine(strategy)
     if args.resume:
@@ -83,7 +83,7 @@ def main() -> None:
     else:
         engine.load_cards(args.file_path)
 
-    interface.run_session(engine)
+    visualizer.run_session(engine)
 
     if args.save:
         engine.save_progress(args.save)

--- a/src/hifz/visualizers/__init__.py
+++ b/src/hifz/visualizers/__init__.py
@@ -6,25 +6,45 @@ from hifz.card_engine import CardEngine
 from hifz.models import Card
 
 
-class CardInterface(ABC):
-    """This ABC represents the CardInterface."""
+class Visualizer(ABC):
+    """Interface for the visualizers."""
 
     @abstractmethod
     def display_card_front(self, card: Card) -> None:
-        """Displays the card front."""
+        """Displays the card front.
+
+        Args:
+            card (Card): The card to display.
+        """
 
     @abstractmethod
     def display_card_back(self, card: Card) -> None:
-        """Displays the card back."""
+        """Displays the card back.
+
+        Args:
+            card (Card): The card to display.
+        """
 
     @abstractmethod
     def notify(self, message: str) -> None:
-        """Notifies with a message."""
+        """Notifies the user with message.
+
+        Args:
+            message (str): The message to notify the user.
+        """
 
     @abstractmethod
     def run_session(self, engine: CardEngine) -> None:
-        """Runs the session."""
+        """Runs the session.
+
+        Args:
+            engine (CardEngine): The engine relevant to starting the session.
+        """
 
     @abstractmethod
     def display_statistics(self, engine: CardEngine) -> None:
-        """Computes the global statistics and displays a representation to be displayed to the user."""
+        """Displays the statistics for the user.
+
+        Args:
+            engine (CardEngine): The engine relevant to the session.
+        """

--- a/src/hifz/visualizers/cli.py
+++ b/src/hifz/visualizers/cli.py
@@ -2,26 +2,42 @@
 
 from hifz.card_engine import CardEngine
 from hifz.models import BinaryFeedback, Card, Feedback, SingleSelectBooleanFeedback
-from hifz.visualizers import CardInterface
+from hifz.visualizers import Visualizer
 
 
-class CLICardInterface(CardInterface):
+class CLIVisualizer(Visualizer):
     """This represents the command-line interface."""
 
     def display_card_front(self, card: Card) -> None:
-        """Displays the card front."""
+        """Displays the card front.
+
+        Args:
+            card (Card): The card to display.
+        """
         print(f"\nFront: {card.front}")  # noqa: T201
 
     def display_card_back(self, card: Card) -> None:
-        """Displays the card back."""
+        """Displays the card back.
+
+        Args:
+            card (Card): The card to display.
+        """
         print(f"Back: {card.back}")  # noqa: T201
 
     def notify(self, message: str) -> None:
-        """Notifies with message."""
+        """Notifies the user with message.
+
+        Args:
+            message (str): The message to notify the user.
+        """
         print(message)  # noqa: T201
 
     def display_statistics(self, engine: CardEngine) -> None:
-        """Notifies the user of the global statistics."""
+        """Displays the statistics for the user.
+
+        Args:
+            engine (CardEngine): The engine relevant to the session.
+        """
         statistics = engine.aggregate_statistics()
         self.notify("\n".join(f"{key}: {val}" for key, val in statistics.items()))
 
@@ -62,7 +78,11 @@ class CLICardInterface(CardInterface):
         return feedback
 
     def run_session(self, engine: CardEngine) -> None:
-        """Runs the session."""
+        """Runs the session.
+
+        Args:
+            engine (CardEngine): The engine relevant to starting the session.
+        """
         self.notify(
             "Starting flashcard session... Type 'q' to quit, 'reload' to load new cards."
         )

--- a/src/hifz/visualizers/gui.py
+++ b/src/hifz/visualizers/gui.py
@@ -17,10 +17,10 @@ from PyQt6.QtWidgets import (  # type: ignore[import-not-found]
 
 from hifz.card_engine import CardEngine
 from hifz.models import BinaryFeedback, Card, Feedback, SingleSelectBooleanFeedback
-from hifz.visualizers import CardInterface
+from hifz.visualizers import Visualizer
 
 
-class GUICardInterface(CardInterface):
+class GUIVisualizer(Visualizer):
     """This class maintains the GUI."""
 
     def __init__(self) -> None:
@@ -134,26 +134,46 @@ class GUICardInterface(CardInterface):
             self.notify(str(e))
 
     def display_card_front(self, card: Card) -> None:
-        """Displays the card front."""
+        """Displays the card front.
+
+        Args:
+            card (Card): The card to display.
+        """
         self.card_label.setText(f"Front: {card.front}")
         self.is_front = True
 
     def display_card_back(self, card: Card) -> None:
-        """Displays the card back."""
+        """Displays the card back.
+
+        Args:
+            card (Card): The card to display.
+        """
         self.card_label.setText(f"Back: {card.back}")
         self.is_front = False
 
     def notify(self, message: str) -> None:
-        """Notifies the user with a message."""
+        """Notifies the user with message.
+
+        Args:
+            message (str): The message to notify the user.
+        """
         QMessageBox.information(self.window, "Notification", message)
 
     def display_statistics(self, engine: CardEngine) -> None:
-        """Notifies the user of the global statistics."""
+        """Displays the statistics for the user.
+
+        Args:
+            engine (CardEngine): The engine relevant to the session.
+        """
         statistics = engine.aggregate_statistics()
         self.notify("\n".join(f"{key}: {val}" for key, val in statistics.items()))
 
     def run_session(self, engine: CardEngine) -> None:
-        """Launches the session."""
+        """Runs the session.
+
+        Args:
+            engine (CardEngine): The engine relevant to starting the session.
+        """
         self.engine = engine
         self.show_next_card()
         self.window.show()

--- a/tests/test_visualizers.py
+++ b/tests/test_visualizers.py
@@ -1,5 +1,5 @@
 from hifz.models import Card
-from hifz.visualizers.cli import CLICardInterface
+from hifz.visualizers.cli import CLIVisualizer
 
 
 def test_cli_display_card_front(mocker):
@@ -14,11 +14,11 @@ def test_cli_display_card_front(mocker):
     Asserts:
         - `print` is called once with the correct text for the card's front.
     """
-    interface = CLICardInterface()
+    visualizer = CLIVisualizer()
     card = Card("Hello", "World")
 
     mocked_print = mocker.patch("builtins.print")
-    interface.display_card_front(card)
+    visualizer.display_card_front(card)
     mocked_print.assert_called_once_with("\nFront: Hello")
 
 
@@ -34,9 +34,9 @@ def test_cli_display_card_back(mocker):
     Asserts:
         - `print` is called once with the correct text for the card's back.
     """
-    interface = CLICardInterface()
+    visualizer = CLIVisualizer()
     card = Card("Hello", "World")
 
     mocked_print = mocker.patch("builtins.print")
-    interface.display_card_back(card)
+    visualizer.display_card_back(card)
     mocked_print.assert_called_once_with("Back: World")


### PR DESCRIPTION
Visualizers were incorrectly named as interfaces, this is a refactoring where all instances of visualizers are renamed.